### PR TITLE
Fix CSP: OSM img-src

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -54,6 +54,7 @@ permalink: .htaccess
     Header always append X-Frame-Options SAMEORIGIN
     Header set Content-Security-Policy "
       default-src 'self';
+      img-src 'self' https://*.openstreetmap.org;
       script-src 'self' 'unsafe-eval' 'unsafe-inline' https://api.github.com https://unpkg.com https://instant.page https://cdn.jsdelivr.net https://*.openstreetmap.org;
       worker-src sw.js;
     "


### PR DESCRIPTION
### Quel problème cette PR corrige-t-elle ?

> Content Security Policy: Les paramètres de la page ont empêché le chargement d’une ressource à https://b.tile.openstreetmap.org/12/2064/1495.png

@bastnic

### Quels sont les changement(s) apporté(s) ?

- Modification du .htaccess : Ajout d'une autorisation ( merci @nico3333fr )

### Qui devrait être prévenu de cette demande ?

@sudweb/thym
